### PR TITLE
Generate position-independent (PIE) code

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -2,7 +2,8 @@ LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
 
-LOCAL_CFLAGS   = -std=c99
+LOCAL_CFLAGS += -fPIE -std=c99
+LOCAL_LDFLAGS += -fPIE -pie
 
 LOCAL_C_INCLUDES := \
 	./jni/regex \
@@ -10,6 +11,7 @@ LOCAL_C_INCLUDES := \
 
 LOCAL_MODULE    := inotifywait
 LOCAL_SRC_FILES := wrap.c common.c libinotifytools/inotifytools.c libinotifytools/redblack.c
+
 
 include $(BUILD_EXECUTABLE)
 


### PR DESCRIPTION
For Android 5 it is necessary to generate position independent code (PIE).
I have added the necessary compiler & linker flags.

tested with android-ndk-r10d.
